### PR TITLE
Delay executions of triggers to help tackle (#94)

### DIFF
--- a/twine/common/db-schema.c
+++ b/twine/common/db-schema.c
@@ -505,6 +505,10 @@ spindle_db_migrate_(SQL *restrict sql, const char *identifier, int newversion, v
 		{
 			return -1;
 		}
+		if(sql_execute(sql, "CREATE INDEX \"triggers_earliest_activation\" ON \"triggers\" (\"earliest_activation\")"))
+		{
+			return -1;
+		}
 		return 0;
 	}
 	twine_logf(LOG_NOTICE, PLUGIN_NAME ": unsupported database schema version %d\n", newversion);

--- a/twine/common/db-schema.c
+++ b/twine/common/db-schema.c
@@ -501,7 +501,7 @@ spindle_db_migrate_(SQL *restrict sql, const char *identifier, int newversion, v
 	// Version 25 introduces a timestamp to delay the execution of the triggers
 	if(newversion == 25)
 	{
-		if(sql_execute(sql, "ALTER TABLE \"triggers\" ADD COLUMN \"earliest_activation\" TIMESTAMP DEFAULT NULL"))
+		if(sql_execute(sql, "ALTER TABLE \"triggers\" ADD COLUMN \"earliest_activation\" TIMESTAMP DEFAULT NOW()"))
 		{
 			return -1;
 		}

--- a/twine/common/db-schema.c
+++ b/twine/common/db-schema.c
@@ -27,7 +27,7 @@
  * 1..DB_SCHEMA_VERSION must be handled individually in spindle_db_migrate_
  * below.
  */
-#define DB_SCHEMA_VERSION               24
+#define DB_SCHEMA_VERSION               25
 
 static int spindle_db_migrate_(SQL *restrict, const char *identifier, int newversion, void *restrict userdata);
 
@@ -493,6 +493,15 @@ spindle_db_migrate_(SQL *restrict sql, const char *identifier, int newversion, v
 			return -1;
 		}
 		if(sql_execute(sql, "CREATE INDEX \"licenses_audiences_audienceid\" ON \"licenses_audiences\" (\"audienceid\")"))
+		{
+			return -1;
+		}
+		return 0;
+	}
+	// Version 25 introduces a timestamp to delay the execution of the triggers
+	if(newversion == 25)
+	{
+		if(sql_execute(sql, "ALTER TABLE \"triggers\" ADD COLUMN \"earliest_activation\" TIMESTAMP DEFAULT NULL"))
 		{
 			return -1;
 		}

--- a/twine/generate/triggers.c
+++ b/twine/generate/triggers.c
@@ -163,17 +163,11 @@ int
 spindle_triggers_index(SQL *sql, const char *id, SPINDLEENTRY *data)
 {
 	size_t c;
-	char nextactivationstr[32];
-	time_t now;
-	struct tm tm;
 
 	for(c = 0; c < data->ntriggers; c++)
 	{
-		now = time(NULL);
-		gmtime_r(&now, &tm);
-		strftime(nextactivationstr, 32, "%Y-%m-%d %H:%M:%S", &tm);
-		if(sql_executef(sql, "INSERT INTO \"triggers\" (\"id\", \"uri\", \"flags\", \"triggerid\", \"earliest_activation\""") VALUES (%Q, %Q, '%d', %Q, %Q)",
-			id, data->triggers[c].uri, data->triggers[c].kind, data->triggers[c].id, nextactivationstr))
+		if(sql_executef(sql, "INSERT INTO \"triggers\" (\"id\", \"uri\", \"flags\", \"triggerid\", \"earliest_activation\""") VALUES (%Q, %Q, '%d', %Q, NOW())",
+			id, data->triggers[c].uri, data->triggers[c].kind, data->triggers[c].id))
 		{
 			return -1;
 		}

--- a/twine/generate/triggers.c
+++ b/twine/generate/triggers.c
@@ -75,12 +75,15 @@ spindle_trigger_apply(SPINDLEENTRY *entry)
 	SQL_STATEMENT *rs;
 	int flags;
 	char *id;
+	char nextactivationstr[32];
+	time_t now;
+	struct tm tm;
 	
 	if(!entry->generate->db)
 	{
 		return 0;
 	}
-	rs = sql_queryf(entry->generate->db, "SELECT \"id\", \"flags\", \"triggerid\" FROM \"triggers\" WHERE \"triggerid\" = %Q AND \"triggerid\" <> \"id\"", entry->id);
+	rs = sql_queryf(entry->generate->db, "SELECT \"id\", \"flags\", \"triggerid\" FROM \"triggers\" WHERE \"triggerid\" = %Q AND \"triggerid\" <> \"id\" AND \"earliest_activation\" < NOW()", entry->id);
 	if(!rs)
 	{
 		return -1;
@@ -93,7 +96,7 @@ spindle_trigger_apply(SPINDLEENTRY *entry)
 		// Get the flags to apply
 		flags = (int) sql_stmt_long(rs, 1);
 
-		/* Trigger updates that have this entry's flag in scope */
+		// Trigger updates that have this entry's flag in scope
 		if (entry->flags & flags)
 		{
 			// Do a logical OR if there is already a trigger scheduled (status = DIRTY and flags <> 0)
@@ -105,6 +108,13 @@ spindle_trigger_apply(SPINDLEENTRY *entry)
 			// Set the target as DIRTY
 			sql_executef(entry->generate->db, "UPDATE \"state\" SET \"status\" = %Q WHERE \"id\" = %Q", "DIRTY", id);
 		}
+
+		// Set the earliest activation date some time in the future
+		now = time(NULL);
+		now += 10; // TODO As for the next fetch in Anansi, this should be made configurable.
+		gmtime_r(&now, &tm);
+		strftime(nextactivationstr, 32, "%Y-%m-%d %H:%M:%S", &tm);
+		sql_executef(entry->generate->db, "UPDATE \"triggers\" SET \"earliest_activation\" = %Q WHERE \"triggerid\" = %Q AND \"earliest_activation\" < NOW()", nextactivationstr, id);
 	}
 	
 	sql_stmt_destroy(rs);
@@ -153,11 +163,17 @@ int
 spindle_triggers_index(SQL *sql, const char *id, SPINDLEENTRY *data)
 {
 	size_t c;
+	char nextactivationstr[32];
+	time_t now;
+	struct tm tm;
 
 	for(c = 0; c < data->ntriggers; c++)
 	{
-		if(sql_executef(sql, "INSERT INTO \"triggers\" (\"id\", \"uri\", \"flags\", \"triggerid\""") VALUES (%Q, %Q, '%d', %Q)",
-			id, data->triggers[c].uri, data->triggers[c].kind, data->triggers[c].id))
+		now = time(NULL);
+		gmtime_r(&now, &tm);
+		strftime(nextactivationstr, 32, "%Y-%m-%d %H:%M:%S", &tm);
+		if(sql_executef(sql, "INSERT INTO \"triggers\" (\"id\", \"uri\", \"flags\", \"triggerid\", \"earliest_activation\""") VALUES (%Q, %Q, '%d', %Q, %Q)",
+			id, data->triggers[c].uri, data->triggers[c].kind, data->triggers[c].id, nextactivationstr))
 		{
 			return -1;
 		}


### PR DESCRIPTION
This does not prevent the loops but slows down their execution to give a chance to the rest to be processed.